### PR TITLE
Fix funnel step tracking

### DIFF
--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -16,7 +16,7 @@ export default function CaseStudiesPage() {
             designSystem: 'arco-design-v3'
         });
 
-        trackFunnelStep('case-studies', 'view', {
+        trackFunnelStep('case-studies', 'view', 1, {
             entryPoint: document.referrer || 'direct'
         });
     }, []);

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -15,7 +15,7 @@ export default function ContactPage() {
             designSystem: 'arco-design-v3'
         });
 
-        trackFunnelStep('contact', 'view', {
+        trackFunnelStep('contact', 'view', 1, {
             entryPoint: document.referrer || 'direct'
         });
     }, []);
@@ -64,7 +64,7 @@ export default function ContactPage() {
             });
 
             // Track conversion
-            trackFunnelStep('contact', 'submit', {
+            trackFunnelStep('contact', 'submit', 2, {
                 formId: 'contact-form'
             });
         }, 1200);

--- a/src/app/diagnose/page-enhanced.tsx
+++ b/src/app/diagnose/page-enhanced.tsx
@@ -21,7 +21,7 @@ const DiagnosePage = () => {
             designSystem: 'arco-design-v3'
         });
 
-        trackFunnelStep('diagnose', 'view', {
+        trackFunnelStep('diagnose', 'view', 1, {
             entryPoint: document.referrer || 'direct'
         });
     }, []);

--- a/src/app/solutions/page.tsx
+++ b/src/app/solutions/page.tsx
@@ -21,7 +21,7 @@ export default function SolutionsPage() {
             designSystem: 'arco-design-v3'
         });
 
-        trackFunnelStep('solutions', 'view', {
+        trackFunnelStep('solutions', 'view', 1, {
             entryPoint: document.referrer || 'direct'
         });
     }, []);


### PR DESCRIPTION
## Summary
- fix the order of arguments when calling `trackFunnelStep` on several pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa21de528832394870f5ba264d46a